### PR TITLE
Update responseMessage type

### DIFF
--- a/.changeset/tricky-keys-vanish.md
+++ b/.changeset/tricky-keys-vanish.md
@@ -1,0 +1,5 @@
+---
+'elysia-rate-limit': patch
+---
+
+responseMessage type has been changed to `any`, so you can actually return response as anything (i.e. object)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ HTTP reponse code to be sent when rate limit was reached. By default, it will re
 
 ### responseMessage
 
-`string`
+`any`
 
 Default: `rate-limit reached`
 

--- a/src/@types/Options.ts
+++ b/src/@types/Options.ts
@@ -14,7 +14,7 @@ export interface Options {
   responseCode: number
 
   // message response when rate-limit reached (Default: rate-limit reached)
-  responseMessage: string
+  responseMessage: any
 
   // should rate limit being counted when request result is failed (Default: false)
   countFailedRequest: boolean


### PR DESCRIPTION
This change is needed in order to send any message, not only limit it to string.
![imagen](https://github.com/rayriffy/elysia-rate-limit/assets/57068341/fb536e04-75ad-4239-adfc-55d01390267c)
This is the workaround I had to do to send a json (works, but it would be great if the type is not restricted only to string)