### PR TITLE
Calculate new nextReset when calling reset()

### DIFF
--- a/src/constants/defaultContext.ts
+++ b/src/constants/defaultContext.ts
@@ -37,7 +37,10 @@ export class DefaultContext implements Context {
 
   async reset(key?: string) {
     if (typeof key === 'string') delete this.store[key]
-    else this.store = {}
+    else {
+      this.store = {}
+      this.nextReset = getNextResetTime(this.duration)
+    }
   }
 
   kill() {


### PR DESCRIPTION
nextReset should be calculated again when calling reset(), otherwise the time will always be the one calculated during init(), and the message will be out of sync.