### PR TITLE
add allowList option to exclude ips from rate limiting

### DIFF
--- a/.changeset/violet-adults-march.md
+++ b/.changeset/violet-adults-march.md
@@ -1,0 +1,5 @@
+---
+'elysia-rate-limit': minor
+---
+
+Add second parameter to skip with the key so requests can be skipped based on their key

--- a/README.md
+++ b/README.md
@@ -101,11 +101,3 @@ export class CustomContext implements Context {
 Default: `(): false`
 
 A custom function to determine that should this request be counted into rate-limit or not based on information given by `Request` object (i.e. Skip counting rate-limit on some route), by default this will always return `false` which means counted everything.
-
-### allowList
-
-`| string[] | ((req: Request, key: string) => boolean | Promise<boolean>)`
-
-Default: `[]`
-
-A list of keys to be excluded from rate-limiting. It can be an array of strings, or a function that takes a `Request` object and the key and returns a boolean or a Promise of a boolean.

--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ export class CustomContext implements Context {
 
 ### skip
 
-`(request: Request): boolean | Promise<boolean>`
+`(request: Request, key: string): boolean | Promise<boolean>`
 
 Default: `(): false`
 
-A custom function to determine that should this request be counted into rate-limit or not based on information given by `Request` object (i.e. Skip counting rate-limit on some route), by default this will always return `false` which means counted everything.
+A custom function to determine that should this request be counted into rate-limit or not based on information given by `Request` object (i.e. Skip counting rate-limit on some route) and the key of the given request, by default this will always return `false` which means counted everything.

--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ If you deploy your server behind a proxy (i.e. NGINX, Cloudflare), you may need 
 ```js
 const cloudflareGenerator = (req, server) =>
   // get client ip via cloudflare header first
-  req.headers.get('CF-Connecting-IP')
+  req.headers.get('CF-Connecting-IP') ??
   // if not found, fallback to default generator
-  ?? server?.requestIP(req)?.address
-  ?? ''
+  server?.requestIP(req)?.address ??
+  ''
 ```
 
 ### countFailedRequest
@@ -101,3 +101,11 @@ export class CustomContext implements Context {
 Default: `(): false`
 
 A custom function to determine that should this request be counted into rate-limit or not based on information given by `Request` object (i.e. Skip counting rate-limit on some route), by default this will always return `false` which means counted everything.
+
+### allowList
+
+`| string[] | ((req: Request, key: string) => boolean | Promise<boolean>)`
+
+Default: `[]`
+
+A list of keys to be excluded from rate-limiting. It can be an array of strings, or a function that takes a `Request` object and the key and returns a boolean or a Promise of a boolean.

--- a/src/@types/Options.ts
+++ b/src/@types/Options.ts
@@ -26,5 +26,5 @@ export interface Options {
   context: Context
 
   // exposed functions for writing custom script to skip counting i.e. not counting rate limit for some requests (Default: always return false)
-  skip: (req: Request, key?: string) => boolean | Promise<boolean>
+  skip: (req: Request, key: string) => boolean | Promise<boolean>
 }

--- a/src/@types/Options.ts
+++ b/src/@types/Options.ts
@@ -27,4 +27,9 @@ export interface Options {
 
   // exposed functions for writing custom script to skip counting i.e. not counting rate limit for some requests (Default: always return false)
   skip: (request: Request) => MaybePromise<boolean>
+
+  // list of keys to be excluded from rate-limiting
+  allowList?:
+    | string[]
+    | ((req: Request, key: string) => boolean | Promise<boolean>)
 }

--- a/src/@types/Options.ts
+++ b/src/@types/Options.ts
@@ -26,10 +26,5 @@ export interface Options {
   context: Context
 
   // exposed functions for writing custom script to skip counting i.e. not counting rate limit for some requests (Default: always return false)
-  skip: (request: Request) => MaybePromise<boolean>
-
-  // list of keys to be excluded from rate-limiting
-  allowList?:
-    | string[]
-    | ((req: Request, key: string) => boolean | Promise<boolean>)
+  skip: (req: Request, key?: string) => boolean | Promise<boolean>
 }

--- a/src/constants/defaultOptions.ts
+++ b/src/constants/defaultOptions.ts
@@ -12,4 +12,5 @@ export const defaultOptions: Options = {
   generator: keyGenerator,
   context: new DefaultContext(),
   skip: () => false,
+  allowList: [],
 }

--- a/src/constants/defaultOptions.ts
+++ b/src/constants/defaultOptions.ts
@@ -12,5 +12,4 @@ export const defaultOptions: Options = {
   generator: keyGenerator,
   context: new DefaultContext(),
   skip: () => false,
-  allowList: [],
 }

--- a/src/services/plugin.ts
+++ b/src/services/plugin.ts
@@ -18,7 +18,10 @@ export const plugin = (userOptions?: Partial<Options>) => {
 
   return (app: Elysia) => {
     app.onBeforeHandle(async ({ set, request }) => {
-      if (options.skip.length < 2 && (await options.skip(request)) === false) {
+      if (
+        options.skip.length < 2 &&
+        (await (options.skip as any)(request)) === false
+      ) {
         const clientKey = await options.generator(request, app.server)
 
         logger('generator', 'generated key is %s', clientKey)

--- a/src/services/plugin.ts
+++ b/src/services/plugin.ts
@@ -39,6 +39,17 @@ export const plugin = (userOptions?: Partial<Options>) => {
           Math.max(0, Math.ceil((nextReset.getTime() - Date.now()) / 1000))
         )
 
+        // Don't apply any rate limiting if in the allow list
+        if (options.allowList) {
+          if (typeof options.allowList === 'function') {
+            if (await options.allowList(request, clientKey)) {
+              return
+            }
+          } else if (options.allowList.indexOf(clientKey) !== -1) {
+            return
+          }
+        }
+
         // reject if limit were reached
         if (payload.current >= payload.limit + 1) {
           set.headers['Retry-After'] = String(


### PR DESCRIPTION
This adds the optional option of having an allowList of ips (or keys) that will be excluded from rate-limiting, which is useful in scenarios where you don't want to restrict machines in your own network.