### PR TITLE
Plugin hooks scoping

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,8 @@
+{
+  "mode": "pre",
+  "tag": "beta",
+  "initialVersions": {
+    "elysia-rate-limit": "3.1.1"
+  },
+  "changesets": []
+}

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -4,5 +4,7 @@
   "initialVersions": {
     "elysia-rate-limit": "3.1.1"
   },
-  "changesets": []
+  "changesets": [
+    "twelve-dots-build"
+  ]
 }

--- a/.changeset/twelve-dots-build.md
+++ b/.changeset/twelve-dots-build.md
@@ -1,0 +1,5 @@
+---
+'elysia-rate-limit': minor
+---
+
+allowing user to change plugin hooks scoping behavior

--- a/.npmignore
+++ b/.npmignore
@@ -12,7 +12,6 @@ nodemon.json
 example
 tests
 test
-CHANGELOG.md
 .eslintrc.js
 tsconfig.cjs.json
 tsconfig.esm.json
@@ -20,3 +19,4 @@ tsconfig.esm.json
 .changeset
 .github
 .idea
+docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # elysia-rate-limit
 
+## 3.2.0-beta.1
+
+### Minor Changes
+
+- 37dc931: allowing user to change plugin hooks scoping behavior
+
 ## 3.1.4
 
 ### Patch Changes

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ If you're using Bun v1.0.3 or lower, `elysia-rate-limit` v2.0.0 or higher will n
 
 ## Compatibility
 
-As long as you're on latest version of Bun, and Elysia. Using latest version of `elysia-rate-limit` would works just fine. However, please refer to following table to determine which version to use.
+As long as you're on the latest version of Bun, and Elysia.
+Using the latest version of `elysia-rate-limit` would works just fine.
+However, please refer to the following table to determine which version to use.
 
 | Plugin version | Requirements |
 | - | - |
@@ -39,7 +41,8 @@ new Elysia().use(rateLimit()).listen(3000)
 
 Default: `60000`
 
-Duration for requests to be remembered in **miliseconds**. Also used in the `Retry-After` header when the limit is reached.
+Duration for requests to be remembered in **milliseconds**.
+Also used in the `Retry-After` header when the limit is reached.
 
 ### max
 
@@ -55,7 +58,10 @@ Maximum of request to be allowed during 1 `duration` timeframe.
 
 Default: `429`
 
-HTTP reponse code to be sent when rate limit was reached. By default, it will return `429 Too Many Requests` refering to [RFC 6585 specification](https://www.rfc-editor.org/rfc/rfc6585#section-4)
+HTTP response code to be sent when the rate limit was reached.
+By default,
+it will return `429 Too Many Requests`
+referring to [RFC 6585 specification](https://www.rfc-editor.org/rfc/rfc6585#section-4)
 
 ### responseMessage
 
@@ -63,7 +69,20 @@ HTTP reponse code to be sent when rate limit was reached. By default, it will re
 
 Default: `rate-limit reached`
 
-Message to be sent when rate limit was reached
+Message to be sent when the rate limit was reached
+
+### scoping
+
+`'global' | 'local'`
+
+Default: `'global'`
+
+Sometimes you may want
+to only apply rate limit plugin to curtain Elysia instance.
+This option will allow you
+to choose scope `local` apply to only current instance and descendant only.
+But by default,
+rate limit plugin will apply to all instances that apply the plugin.
 
 ### generator
 
@@ -88,7 +107,11 @@ const cloudflareGenerator = (req, server) =>
 
 Default: `false`
 
-Should this plugin count rate-limit to user when request failed? By default, this plugin will refund request count to client when `onError` lifecycle called. ([Learn more in Lifecycle](https://elysiajs.com/concept/middleware.html#life-cycle))
+Should this plugin count rate-limit to user when request failed?
+By default,
+this plugin will refund request count to a client
+when `onError` lifecycle called.
+([Learn more in Lifecycle](https://elysiajs.com/concept/middleware.html#life-cycle))
 
 ### context
 
@@ -124,4 +147,8 @@ new Elysia()
 
 Default: `(): false`
 
-A custom function to determine that should this request be counted into rate-limit or not based on information given by `Request` object (i.e. Skip counting rate-limit on some route) and the key of the given request, by default this will always return `false` which means counted everything.
+A custom function
+to determine that should this request be counted into rate-limit
+or not based on information given by `Request` object
+(i.e., Skip counting rate-limit on some route) and the key of the given request,
+by default, this will always return `false` which means counted everything.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elysia-rate-limit",
-  "version": "3.1.4",
+  "version": "3.2.0-beta.1",
   "description": "Rate-limiter for Elysia.js",
   "author": {
     "name": "rayriffy",

--- a/src/@types/Options.ts
+++ b/src/@types/Options.ts
@@ -16,6 +16,9 @@ export interface Options {
   // message response when rate-limit reached (Default: rate-limit reached)
   responseMessage: any
 
+  // scoping for rate limiting, set global by default to affect every request, but you can adjust to local to affect only within current instance
+  scoping: 'global' | 'local'
+
   // should the rate limit be counted when a request result is failed (Default: false)
   countFailedRequest: boolean
 

--- a/src/constants/defaultOptions.ts
+++ b/src/constants/defaultOptions.ts
@@ -8,6 +8,7 @@ export const defaultOptions: Options = {
   max: 10,
   responseCode: 429,
   responseMessage: 'rate-limit reached',
+  scoping: 'global',
   countFailedRequest: false,
   generator: defaultKeyGenerator,
   context: new DefaultContext(),

--- a/src/services/plugin.ts
+++ b/src/services/plugin.ts
@@ -17,7 +17,7 @@ export const plugin = (userOptions?: Partial<Options>) => {
   options.context.init(options)
 
   return (app: Elysia) => {
-    app.onBeforeHandle({ as: 'global' }, async ({ set, request }) => {
+    app.onBeforeHandle({ as: options.scoping }, async ({ set, request }) => {
       let clientKey: string | undefined
 
       /**

--- a/src/services/plugin.ts
+++ b/src/services/plugin.ts
@@ -68,7 +68,7 @@ export const plugin = (userOptions?: Partial<Options>) => {
       }
     })
 
-    app.onError(async ({ request }) => {
+    app.onError({ as: options.scoping }, async ({ request }) => {
       if (!options.countFailedRequest) {
         const clientKey = await options.generator(request, app.server)
         await options.context.decrement(clientKey)


### PR DESCRIPTION
Currently, `elysia-rate-limit` plugin will apply to all instances that apply the plugin (all ascendants, current, and descendants) which some user may want to create separate rate limit instance per each Elysia instance they created.

Introducing `scoping` option, now user can manually set hooks scope to `local` for plugin affect to only current instance and descendant only.