### PR TITLE
Derive values

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "beta",
   "initialVersions": {
     "elysia-rate-limit": "3.1.4"

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -2,9 +2,9 @@
   "mode": "pre",
   "tag": "beta",
   "initialVersions": {
-    "elysia-rate-limit": "3.1.1"
+    "elysia-rate-limit": "3.1.4"
   },
   "changesets": [
-    "twelve-dots-build"
+    "silent-trains-sing"
   ]
 }

--- a/.changeset/silent-trains-sing.md
+++ b/.changeset/silent-trains-sing.md
@@ -1,0 +1,5 @@
+---
+'elysia-rate-limit': minor
+---
+
+generators function now passed derive values as a thrid argruments

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,22 @@
+name: PR Checks
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+      - name: install
+        run: bun i
+      - name: build
+        run: bun run build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 - 37dc931: allowing user to change plugin hooks scoping behavior
 
+## 3.2.0-beta.0
+
+### Minor Changes
+
+- generators function now passed derive values as a thrid argruments
+
 ## 3.1.4
 
 ### Patch Changes

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ As long as you're on the latest version of Bun, and Elysia.
 Using the latest version of `elysia-rate-limit` would works just fine.
 However, please refer to the following table to determine which version to use.
 
-| Plugin version | Requirements |
-| - | - |
-| 3.0.0+ | Bun > 1.0.3, Elysia >= 1.0.0 |
-| 2.0.0 - 2.2.0 | Bun > 1.0.3, Elysia < 1.0.0 |
-| 1.0.2 - 1.3.0 | Bun <= 1.0.3, Elysia < 1.0.0 |
+| Plugin version | Requirements                 |
+|----------------|------------------------------|
+| 3.0.0+         | Bun > 1.0.3, Elysia >= 1.0.0 |
+| 2.0.0 - 2.2.0  | Bun > 1.0.3, Elysia < 1.0.0  |
+| 1.0.2 - 1.3.0  | Bun <= 1.0.3, Elysia < 1.0.0 |
 
 ## Usage
 
@@ -86,7 +86,7 @@ rate limit plugin will apply to all instances that apply the plugin.
 
 ### generator
 
-`(request: Request, server: Server): string | Promise<string>`
+`<T extends object>(equest: Request, server: Server | null, derived: T) => MaybePromise<string>`
 
 Custom key generator to categorize client requests, return as a string. By default, this plugin will categorize client by their IP address via [`server.requestIP()` function](https://github.com/oven-sh/bun/pull/6165).
 
@@ -99,6 +99,22 @@ const cloudflareGenerator = (req, server) =>
   // if not found, fallback to default generator
   server?.requestIP(req)?.address ??
   ''
+```
+
+There's a third argument
+where you can use derive values from external plugin within key generator as well.
+Only downsize is you have to definitely those types be yourself,
+please be sure to test those values before actually defining types manually.
+
+```ts
+import { ip } from 'elysia-ip'
+
+import type { SocketAddress } from 'bun'
+import type { Generator } from 'elysia-rate-limit'
+
+const ipGenerator: Generator<{ ip: SocketAddress }> = (_req, _serv, { ip }) => {
+  return ip
+} 
 ```
 
 ### countFailedRequest

--- a/example/index.ts
+++ b/example/index.ts
@@ -1,8 +1,10 @@
 import { Elysia } from 'elysia'
 
+import { ip } from '../node_modules/elysia-ip/src'
 import { rateLimit } from '../src'
 
 const app = new Elysia()
+  .use(ip())
   .use(rateLimit())
   .get('/', () => 'hello')
   .listen(3000)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elysia-rate-limit",
-  "version": "3.2.0-beta.1",
+  "version": "3.1.4",
   "description": "Rate-limiter for Elysia.js",
   "author": {
     "name": "rayriffy",

--- a/src/@types/Generator.ts
+++ b/src/@types/Generator.ts
@@ -1,0 +1,4 @@
+import type { Server } from 'bun'
+import type { MaybePromise } from 'elysia'
+
+export type Generator = <T extends object>(equest: Request, server: Server | null, derived: T) => MaybePromise<string>

--- a/src/@types/Options.ts
+++ b/src/@types/Options.ts
@@ -1,7 +1,5 @@
-import type { MaybePromise } from 'elysia'
-
 import type { Context } from './Context'
-import type { Server } from 'bun'
+import { Generator } from './Generator'
 
 export interface Options {
   // The duration for plugin to remember the requests (Default: 60000ms)
@@ -23,7 +21,7 @@ export interface Options {
   countFailedRequest: boolean
 
   // key generator function to categorize client for rate-limiting
-  generator(request: Request, server: Server | null, derived: any): MaybePromise<string>
+  generator: Generator
 
   // context for storing requests count
   context: Context

--- a/src/@types/Options.ts
+++ b/src/@types/Options.ts
@@ -23,7 +23,7 @@ export interface Options {
   countFailedRequest: boolean
 
   // key generator function to categorize client for rate-limiting
-  generator(request: Request, server: Server | null): MaybePromise<string>
+  generator(request: Request, server: Server | null, derived: any): MaybePromise<string>
 
   // context for storing requests count
   context: Context

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
 export { plugin as rateLimit } from './services/plugin'
 export { DefaultContext } from './services/defaultContext'
+
 export type { Context } from './@types/Context'
 export type { Options } from './@types/Options'
+export type { Generator } from './@types/Generator'

--- a/src/services/defaultKeyGenerator.ts
+++ b/src/services/defaultKeyGenerator.ts
@@ -1,9 +1,6 @@
-import type { Server } from 'bun'
+import type { Options } from '../@types/Options'
 
-export const defaultKeyGenerator = (
-  request: Request,
-  server: Server | null
-): string => {
+export const defaultKeyGenerator: Options['generator'] = (request, server): string => {
   const clientAddress = server?.requestIP(request)?.address
 
   if (clientAddress === undefined) {

--- a/src/services/plugin.ts
+++ b/src/services/plugin.ts
@@ -17,7 +17,7 @@ export const plugin = (userOptions?: Partial<Options>) => {
   options.context.init(options)
 
   return (app: Elysia) => {
-    // somehow qi is being sent from elysia, but there's no type declaration for it
+    // @ts-expect-error somehow qi is being sent from elysia, but there's no type declaration for it
     app.onBeforeHandle({ as: options.scoping }, async ({ set, request, query, path, store, cookie, error, body, params, headers, qi, ...rest }) => {
       let clientKey: string | undefined
 
@@ -69,9 +69,10 @@ export const plugin = (userOptions?: Partial<Options>) => {
       }
     })
 
-    app.onError({ as: options.scoping }, async ({ request }) => {
+    // @ts-expect-error somehow qi is being sent from elysia, but there's no type declaration for it
+    app.onError({ as: options.scoping }, async ({ set, request, query, path, store, cookie, error, body, params, headers, qi, ...rest }) => {
       if (!options.countFailedRequest) {
-        const clientKey = await options.generator(request, app.server)
+        const clientKey = await options.generator(request, app.server, rest)
         await options.context.decrement(clientKey)
       }
     })

--- a/src/services/plugin.ts
+++ b/src/services/plugin.ts
@@ -17,7 +17,8 @@ export const plugin = (userOptions?: Partial<Options>) => {
   options.context.init(options)
 
   return (app: Elysia) => {
-    app.onBeforeHandle({ as: options.scoping }, async ({ set, request }) => {
+    // somehow qi is being sent from elysia, but there's no type declaration for it
+    app.onBeforeHandle({ as: options.scoping }, async ({ set, request, query, path, store, cookie, error, body, params, headers, qi, ...rest }) => {
       let clientKey: string | undefined
 
       /**
@@ -27,7 +28,7 @@ export const plugin = (userOptions?: Partial<Options>) => {
        * and saving some cpu consumption when actually skipped
        */
       if (options.skip.length >= 2)
-        clientKey = await options.generator(request, app.server)
+        clientKey = await options.generator(request, app.server, rest)
 
       // if decided to skip, then do nothing and let the app continue
       if (await options.skip(request, clientKey) === false) {
@@ -37,7 +38,7 @@ export const plugin = (userOptions?: Partial<Options>) => {
          * then generate one
          */
         if (options.skip.length < 2)
-          clientKey = await options.generator(request, app.server)
+          clientKey = await options.generator(request, app.server, rest)
 
         logger('generator', 'generated key is %s', clientKey)
 


### PR DESCRIPTION
`generators` options gains third parameters to forward all derive values to use. now you can opt-out from unreliable defaultGenerator, and use `elysia-ip` instead.

```ts
import { ip } from 'elysia-ip'
import { rateLimit } from 'elysia-rate-limit'

const app = new Elysia()
  .use(ip())
  .use(rateLimit({
    generator: (req, server, { ip }) => ip.address
  }))
```