### PR TITLE
Add "local" scope option.

### DIFF
--- a/src/@types/Options.ts
+++ b/src/@types/Options.ts
@@ -14,7 +14,7 @@ export interface Options {
 
   // scoping for rate limiting, set global by default to affect every request,
   // but you can adjust to local to affect only within current instance
-  scoping: 'global' | 'scoped'
+  scoping: 'global' | 'scoped' | 'local'
 
   // should the rate limit be counted when a request result is failed (Default: false)
   countFailedRequest: boolean


### PR DESCRIPTION
Add 3rd scoping level of "local" as per available elysiajs plugin scopes. 

Funnily enough the "local" option is written as suggested in the docs but is not actually available as an option value in code.