### PR TITLE
feat: extend rate limit plugin to 404 routes

### DIFF
--- a/.changeset/kind-geckos-refuse.md
+++ b/.changeset/kind-geckos-refuse.md
@@ -1,0 +1,5 @@
+---
+"elysia-rate-limit": patch
+---
+
+extend rate limiting to 404 routes

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -11,39 +11,39 @@ bun run benchmark/index.ts
 Here's the current benchmark results, in theory when plugin were used the performance should be slower than without plugin. So our benchmark target is to reduce the performance difference as much as possible.
 
 ```shell
-clk: ~4.22 GHz
+clk: ~4.20 GHz
 cpu: Apple M4
 runtime: bun 1.3.11 (arm64-darwin)
 
 benchmark                   avg (min … max) p75 / p99    (min … top 1%)
 ------------------------------------------- -------------------------------
-Without Rate Limit           398.00 ns/iter 334.00 ns  █▇                  
-                     (208.00 ns … 68.71 µs)   1.38 µs  ██                  
-                    (  0.00  b …  64.00 kb) 196.55  b ▁██▄▇▃▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁
+Without Rate Limit           399.66 ns/iter 375.00 ns  █▅                  
+                    (208.00 ns … 263.08 µs)   1.79 µs  ██                  
+                    (  0.00  b …  48.00 kb) 193.32  b ▁██▇▃▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
 
-With Rate Limit (Default)      1.88 µs/iter   1.83 µs  █                   
-                      (1.33 µs … 457.00 µs)   5.96 µs  ██                  
-                    (  0.00  b … 144.00 kb) 218.60  b ▂██▇▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
+With Rate Limit (Default)      1.99 µs/iter   1.92 µs  █                   
+                      (1.29 µs … 565.92 µs)   7.00 µs  ██                  
+                    (  0.00  b … 128.00 kb) 223.04  b ▂██▆▃▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
 
-With Rate Limit (Custom)       1.96 µs/iter   1.92 µs  ▄█                  
-                      (1.42 µs … 502.75 µs)   5.79 µs  ██                  
-                    (  0.00  b … 176.00 kb) 362.97  b ▁██▇▃▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
+With Rate Limit (Custom)       2.03 µs/iter   2.00 µs  █▄                  
+                      (1.38 µs … 480.67 µs)   6.67 µs  ██                  
+                    (  0.00  b … 512.00 kb) 379.38  b ▂███▃▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
 
                              ┌                                            ┐
-                             ╷┬       ╷
-          Without Rate Limit ├│───────┤
-                             ╵┴       ╵
-                                      ╷ ┌─┬                               ╷
-   With Rate Limit (Default)          ├─┤ │───────────────────────────────┤
-                                      ╵ └─┴                               ╵
-                                      ╷  ┌─┬                             ╷
-    With Rate Limit (Custom)          ├──┤ │─────────────────────────────┤
-                                      ╵  └─┴                             ╵
+                             ╷┬        ╷
+          Without Rate Limit ├│────────┤
+                             ╵┴        ╵
+                                    ╷ ┌──┬                                ╷
+   With Rate Limit (Default)        ├─┤  │────────────────────────────────┤
+                                    ╵ └──┴                                ╵
+                                     ╷ ┌─┬                              ╷
+    With Rate Limit (Custom)         ├─┤ │──────────────────────────────┤
+                                     ╵ └─┴                              ╵
                              └                                            ┘
-                             208.00 ns           3.08 µs            5.96 µs
+                             208.00 ns           3.60 µs            7.00 µs
 
 summary
   Without Rate Limit
-   4.71x faster than With Rate Limit (Default)
-   4.93x faster than With Rate Limit (Custom)
+   4.98x faster than With Rate Limit (Default)
+   5.08x faster than With Rate Limit (Custom)
 ```

--- a/src/services/plugin.spec.ts
+++ b/src/services/plugin.spec.ts
@@ -106,4 +106,18 @@ describe('rate limit plugin', () => {
     expect(receivedDerived.length).toBeGreaterThan(0)
     expect(receivedDerived[0].customProp).toBe('hello-from-plugin')
   })
+
+  it('should rate limit not found routes', async () => {
+    const app = new Elysia()
+      .use(plugin({ max: 2, duration: 60000, scoping: 'global' }))
+      .get('/known', () => 'ok')
+
+    const r1 = await app.handle(new Request('http://localhost/unknown-route'))
+    const r2 = await app.handle(new Request('http://localhost/unknown-route'))
+    const r3 = await app.handle(new Request('http://localhost/unknown-route'))
+
+    expect(r1.status).toBe(404)
+    expect(r2.status).toBe(404)
+    expect(r3.status).toBe(429)
+  })
 })

--- a/src/services/plugin.ts
+++ b/src/services/plugin.ts
@@ -195,7 +195,104 @@ export const plugin = function rateLimitPlugin(userOptions?: Partial<Options>) {
       async function onErrorRateLimitHandler({
         request,
         cookie,
+        set,
       }) {
+        const context = arguments[0] as Record<string, any>
+        const error = context.error as unknown
+        const code = context.code as unknown
+
+        const errorStatus = typeof error === 'object' && error !== null
+          ? (error as any).status ?? (error as any).statusCode
+          : undefined
+        const currentStatus = typeof set?.status === 'number' ? set.status : undefined
+        const isNotFound = code === 'NOT_FOUND' || currentStatus === 404 || errorStatus === 404
+
+        if (isNotFound) {
+          // attach cookie to request
+          // @ts-expect-error - fast path
+          request.cookie = cookie
+          const enhancedRequest = request as ExtendedRequest
+
+          const clientKey = await options.generator(
+            enhancedRequest,
+            options.injectServer?.() ?? app.server,
+            options.generator === defaultKeyGenerator
+              ? {}
+              : buildDerived(arguments[0])
+          )
+
+          if ((await options.skip(enhancedRequest, clientKey)) === false) {
+            const { count, nextReset } = await options.context.increment(clientKey)
+
+            const maxLimit = typeof options.max === 'function'
+              ? await options.max(clientKey, enhancedRequest)
+              : options.max
+
+            const payload = {
+              limit: maxLimit,
+              current: count,
+              remaining: Math.max(maxLimit - count, 0),
+              nextReset,
+            }
+
+            const reset = Math.max(
+              0,
+              Math.ceil((nextReset.getTime() - Date.now()) / 1000)
+            )
+
+            if (payload.current >= payload.limit + 1) {
+              logger(
+                'plugin',
+                'rate limit exceeded for clientKey: %s (resetting in %d seconds)',
+                clientKey,
+                reset
+              )
+
+              if (options.errorResponse instanceof Error)
+                throw options.errorResponse
+              if (options.errorResponse instanceof Response) {
+                const clonedResponse = options.errorResponse.clone()
+
+                if (options.headers) {
+                  clonedResponse.headers.set('RateLimit-Limit', String(maxLimit))
+                  clonedResponse.headers.set('RateLimit-Remaining', String(payload.remaining))
+                  clonedResponse.headers.set('RateLimit-Reset', String(reset))
+                  clonedResponse.headers.set('Retry-After', String(Math.ceil(options.duration / 1000)))
+                }
+
+                return clonedResponse
+              }
+
+              if (options.headers) {
+                set.headers['RateLimit-Limit'] = String(maxLimit)
+                set.headers['RateLimit-Remaining'] = String(payload.remaining)
+                set.headers['RateLimit-Reset'] = String(reset)
+                set.headers['Retry-After'] = String(Math.ceil(options.duration / 1000))
+              }
+
+              set.status = 429
+              return options.errorResponse
+            }
+
+            if (options.headers) {
+              set.headers['RateLimit-Limit'] = String(maxLimit)
+              set.headers['RateLimit-Remaining'] = String(payload.remaining)
+              set.headers['RateLimit-Reset'] = String(reset)
+            }
+
+            logger(
+              'plugin',
+              'clientKey %s passed through with %d/%d request used (resetting in %d seconds)',
+              clientKey,
+              maxLimit - payload.remaining,
+              maxLimit,
+              reset
+            )
+          }
+
+          return
+        }
+
         if (!options.countFailedRequest) {
           // attach cookie to request
           // @ts-expect-error - fast path

--- a/src/services/plugin.ts
+++ b/src/services/plugin.ts
@@ -48,6 +48,100 @@ export const plugin = function rateLimitPlugin(userOptions?: Partial<Options>) {
       seed: seedValue,
     })
 
+    const getGeneratorDerived = (context: Record<string, unknown>) =>
+      options.generator === defaultKeyGenerator ? {} : buildDerived(context)
+
+    const attachCookieToRequest = (request: Request, cookie: unknown) => {
+      // attach cookie to request
+      // @ts-expect-error - fast path
+      request.cookie = cookie
+      return request as ExtendedRequest
+    }
+
+    const writeRateLimitHeaders = (
+      target: Headers | Record<string, string | number>,
+      maxLimit: number,
+      remaining: number,
+      reset: number,
+      withRetryAfter = false
+    ) => {
+      if (!options.headers)
+        return
+
+      const setHeader = target instanceof Headers
+        ? (name: string, value: string) => target.set(name, value)
+        : (name: string, value: string) => {
+          target[name] = value
+        }
+
+      setHeader('RateLimit-Limit', String(maxLimit))
+      setHeader('RateLimit-Remaining', String(remaining))
+      setHeader('RateLimit-Reset', String(reset))
+
+      if (withRetryAfter)
+        setHeader('Retry-After', String(Math.ceil(options.duration / 1000)))
+    }
+
+    const applyRateLimit = async (
+      set: {
+        headers: Record<string, string | number>
+        status?: number | string
+      },
+      enhancedRequest: ExtendedRequest,
+      clientKey: string
+    ) => {
+      const { count, nextReset } = await options.context.increment(clientKey)
+
+      // Resolve max value (static or dynamic)
+      const maxLimit = typeof options.max === 'function'
+        ? await options.max(clientKey, enhancedRequest)
+        : options.max
+
+      const remaining = Math.max(maxLimit - count, 0)
+      const reset = Math.max(
+        0,
+        Math.ceil((nextReset.getTime() - Date.now()) / 1000)
+      )
+
+      // reject if limit were reached
+      if (count >= maxLimit + 1) {
+        logger(
+          'plugin',
+          'rate limit exceeded for clientKey: %s (resetting in %d seconds)',
+          clientKey,
+          reset
+        )
+
+        if (options.errorResponse instanceof Error)
+          throw options.errorResponse
+
+        if (options.errorResponse instanceof Response) {
+          // duplicate the response to avoid mutation
+          const clonedResponse = options.errorResponse.clone()
+          writeRateLimitHeaders(clonedResponse.headers, maxLimit, remaining, reset, true)
+          return clonedResponse
+        }
+
+        writeRateLimitHeaders(set.headers, maxLimit, remaining, reset, true)
+
+        // set default status code
+        set.status = 429
+
+        return options.errorResponse
+      }
+
+      writeRateLimitHeaders(set.headers, maxLimit, remaining, reset)
+
+      logger(
+        'plugin',
+        'clientKey %s passed through with %d/%d request used (resetting in %d seconds)',
+        clientKey,
+        maxLimit - remaining,
+        maxLimit,
+        reset
+      )
+    }
+
     // IMPORTANT: The lifecycle hooks below intentionally avoid destructuring
     // `body`, `query`, `params`, `headers`, or using `...rest` in the
     // parameter list. Elysia's static analyzer (sucrose) inspects the
@@ -70,12 +164,10 @@ export const plugin = function rateLimitPlugin(userOptions?: Partial<Options>) {
         request,
         cookie,
       }) {
+        const context = arguments[0] as Record<string, unknown>
         let clientKey: string | undefined
 
-        // attach cookie to request
-        // @ts-expect-error - fast path
-        request.cookie = cookie
-        const enhancedRequest = request as ExtendedRequest
+        const enhancedRequest = attachCookieToRequest(request, cookie)
 
         /**
          * if a skip option has two parameters,
@@ -87,9 +179,7 @@ export const plugin = function rateLimitPlugin(userOptions?: Partial<Options>) {
           clientKey = await options.generator(
             enhancedRequest,
             options.injectServer?.() ?? app.server,
-            options.generator === defaultKeyGenerator
-              ? {}
-              : buildDerived(arguments[0])
+            getGeneratorDerived(context)
           )
 
         // if decided to skip, then do nothing and let the app continue
@@ -103,89 +193,18 @@ export const plugin = function rateLimitPlugin(userOptions?: Partial<Options>) {
             clientKey = await options.generator(
               enhancedRequest,
               options.injectServer?.() ?? app.server,
-              options.generator === defaultKeyGenerator
-                ? {}
-                : buildDerived(arguments[0])
+              getGeneratorDerived(context)
             )
 
-          const { count, nextReset } = await options.context.increment(
-            // biome-ignore lint/style/noNonNullAssertion: <explanation>
+          const limitResult = await applyRateLimit(
+            set,
+            enhancedRequest,
+            // biome-ignore lint/style/noNonNullAssertion: generated by current flow
             clientKey!
           )
 
-          // Resolve max value (static or dynamic)
-          const maxLimit = typeof options.max === 'function'
-            ? await options.max(clientKey!, enhancedRequest)
-            : options.max
-
-          const payload = {
-            limit: maxLimit,
-            current: count,
-            remaining: Math.max(maxLimit - count, 0),
-            nextReset,
-          }
-
-          // set standard headers
-          const reset = Math.max(
-            0,
-            Math.ceil((nextReset.getTime() - Date.now()) / 1000)
-          )
-
-          // reject if limit were reached
-          if (payload.current >= payload.limit + 1) {
-            logger(
-              'plugin',
-              'rate limit exceeded for clientKey: %s (resetting in %d seconds)',
-              clientKey,
-              reset
-            )
-
-            if (options.errorResponse instanceof Error)
-              throw options.errorResponse
-            if (options.errorResponse instanceof Response) {
-              // duplicate the response to avoid mutation
-              const clonedResponse = options.errorResponse.clone()
-
-              // append headers
-              if (options.headers) {
-                clonedResponse.headers.set('RateLimit-Limit', String(maxLimit))
-                clonedResponse.headers.set('RateLimit-Remaining', String(payload.remaining))
-                clonedResponse.headers.set('RateLimit-Reset', String(reset))
-                clonedResponse.headers.set('Retry-After', String(Math.ceil(options.duration / 1000)))
-              }
-
-              return clonedResponse
-            }
-
-            // append headers
-            if (options.headers) {
-              set.headers['RateLimit-Limit'] = String(maxLimit)
-              set.headers['RateLimit-Remaining'] = String(payload.remaining)
-              set.headers['RateLimit-Reset'] = String(reset)
-              set.headers['Retry-After'] = String(Math.ceil(options.duration / 1000))
-            }
-
-            // set default status code
-            set.status = 429
-
-            return options.errorResponse
-          }
-
-          // append headers
-          if (options.headers) {
-            set.headers['RateLimit-Limit'] = String(maxLimit)
-            set.headers['RateLimit-Remaining'] = String(payload.remaining)
-            set.headers['RateLimit-Reset'] = String(reset)
-          }
-
-          logger(
-            'plugin',
-            'clientKey %s passed through with %d/%d request used (resetting in %d seconds)',
-            clientKey,
-            maxLimit - payload.remaining,
-            maxLimit,
-            reset
-          )
+          if (limitResult !== undefined)
+            return limitResult
         }
       }
     )
@@ -197,114 +216,47 @@ export const plugin = function rateLimitPlugin(userOptions?: Partial<Options>) {
         cookie,
         set,
       }) {
-        const context = arguments[0] as Record<string, any>
+        const context = arguments[0] as Record<string, unknown>
         const error = context.error as unknown
         const code = context.code as unknown
 
         const errorStatus = typeof error === 'object' && error !== null
-          ? (error as any).status ?? (error as any).statusCode
+          ? (error as {
+            status?: number
+            statusCode?: number
+          }).status ?? (error as {
+            status?: number
+            statusCode?: number
+          }).statusCode
           : undefined
         const currentStatus = typeof set?.status === 'number' ? set.status : undefined
         const isNotFound = code === 'NOT_FOUND' || currentStatus === 404 || errorStatus === 404
 
         if (isNotFound) {
-          // attach cookie to request
-          // @ts-expect-error - fast path
-          request.cookie = cookie
-          const enhancedRequest = request as ExtendedRequest
+          const enhancedRequest = attachCookieToRequest(request, cookie)
 
           const clientKey = await options.generator(
             enhancedRequest,
             options.injectServer?.() ?? app.server,
-            options.generator === defaultKeyGenerator
-              ? {}
-              : buildDerived(arguments[0])
+            getGeneratorDerived(context)
           )
 
           if ((await options.skip(enhancedRequest, clientKey)) === false) {
-            const { count, nextReset } = await options.context.increment(clientKey)
-
-            const maxLimit = typeof options.max === 'function'
-              ? await options.max(clientKey, enhancedRequest)
-              : options.max
-
-            const payload = {
-              limit: maxLimit,
-              current: count,
-              remaining: Math.max(maxLimit - count, 0),
-              nextReset,
-            }
-
-            const reset = Math.max(
-              0,
-              Math.ceil((nextReset.getTime() - Date.now()) / 1000)
-            )
-
-            if (payload.current >= payload.limit + 1) {
-              logger(
-                'plugin',
-                'rate limit exceeded for clientKey: %s (resetting in %d seconds)',
-                clientKey,
-                reset
-              )
-
-              if (options.errorResponse instanceof Error)
-                throw options.errorResponse
-              if (options.errorResponse instanceof Response) {
-                const clonedResponse = options.errorResponse.clone()
-
-                if (options.headers) {
-                  clonedResponse.headers.set('RateLimit-Limit', String(maxLimit))
-                  clonedResponse.headers.set('RateLimit-Remaining', String(payload.remaining))
-                  clonedResponse.headers.set('RateLimit-Reset', String(reset))
-                  clonedResponse.headers.set('Retry-After', String(Math.ceil(options.duration / 1000)))
-                }
-
-                return clonedResponse
-              }
-
-              if (options.headers) {
-                set.headers['RateLimit-Limit'] = String(maxLimit)
-                set.headers['RateLimit-Remaining'] = String(payload.remaining)
-                set.headers['RateLimit-Reset'] = String(reset)
-                set.headers['Retry-After'] = String(Math.ceil(options.duration / 1000))
-              }
-
-              set.status = 429
-              return options.errorResponse
-            }
-
-            if (options.headers) {
-              set.headers['RateLimit-Limit'] = String(maxLimit)
-              set.headers['RateLimit-Remaining'] = String(payload.remaining)
-              set.headers['RateLimit-Reset'] = String(reset)
-            }
-
-            logger(
-              'plugin',
-              'clientKey %s passed through with %d/%d request used (resetting in %d seconds)',
-              clientKey,
-              maxLimit - payload.remaining,
-              maxLimit,
-              reset
-            )
+            const limitResult = await applyRateLimit(set, enhancedRequest, clientKey)
+            if (limitResult !== undefined)
+              return limitResult
           }
 
           return
         }
 
         if (!options.countFailedRequest) {
-          // attach cookie to request
-          // @ts-expect-error - fast path
-          request.cookie = cookie
-          const enhancedRequest = request as ExtendedRequest
-          
+          const enhancedRequest = attachCookieToRequest(request, cookie)
+
           const clientKey = await options.generator(
             enhancedRequest,
             options.injectServer?.() ?? app.server,
-            options.generator === defaultKeyGenerator
-              ? {}
-              : buildDerived(arguments[0])
+            getGeneratorDerived(context)
           )
 
           logger(


### PR DESCRIPTION
## 🎯 Changes

### 1. Rate Limit Plugin Enhancement
- Extend rate limit plugin to enforce limits on not-found (404) routes
- Apply rate limiting flow within the error handler for `NOT_FOUND` resolutions
- Set `RateLimit` headers and return a `429` response when the not-found route rate limit is exceeded

### 2. Test Coverage
- Add a test to verify that repeated hits to an unknown route eventually return a `429` response after exceeding the rate limit

## 💡 Technical Highlights

- **Error Handler Integration**: Rate limiting logic is now integrated into the error handling flow for `NOT_FOUND` errors
- **Consistent Rate Limiting**: Ensures that even requests to non-existent endpoints are subject to rate limits, preventing abuse
- **Robustness**: Prevents potential denial-of-service attacks by repeatedly hitting unknown routes

closes #75 