### PR TITLE
feat: support dynamic duration as a function

### DIFF
--- a/.changeset/cool-dodos-drive.md
+++ b/.changeset/cool-dodos-drive.md
@@ -1,0 +1,5 @@
+---
+"elysia-rate-limit": minor
+---
+
+Support dynamic duration as a function

--- a/.changeset/cool-dodos-drive.md
+++ b/.changeset/cool-dodos-drive.md
@@ -1,5 +1,5 @@
 ---
-"elysia-rate-limit": minor
+"elysia-rate-limit": patch
 ---
 
 Support dynamic duration as a function

--- a/README.md
+++ b/README.md
@@ -41,12 +41,58 @@ new Elysia().use(rateLimit()).listen(3000)
 
 ### duration
 
-`number`
+`number | ((key: string, request: ExtendedRequest) => number | Promise<number>)`
 
 Default: `60000`
 
 Duration for requests to be remembered in **milliseconds**.
 Also used in the `Retry-After` header when the limit is reached.
+
+Can be a static number or a dynamic function that returns the duration based on the client key and request. The function receives:
+- `key`: The generated client key (e.g., IP address)
+- `request`: The request object with cookies attached
+
+> **Note:** The dynamic value is resolved **when a new window opens** for a given key. Changing the duration mid-window has no effect on the current window — it will apply on the next window.
+
+<details>
+<summary>Example for static <code>duration</code></summary>
+
+```ts
+new Elysia().use(
+  rateLimit({
+    duration: 60_000, // 1-minute window
+  })
+)
+```
+</details>
+
+<details>
+<summary>Example for dynamic <code>duration</code></summary>
+
+```ts
+new Elysia().use(
+  rateLimit({
+    duration: (key, request) => {
+      // Give premium users a shorter window
+      const isPremium = request.headers.get('X-User-Tier') === 'premium'
+      return isPremium ? 10_000 : 60_000
+    },
+  })
+)
+```
+
+```ts
+new Elysia().use(
+  rateLimit({
+    duration: async (key, request) => {
+      // Fetch user tier from database
+      const userTier = await getUserTier(key)
+      return userTier === 'premium' ? 10_000 : 60_000
+    },
+  })
+)
+```
+</details>
 
 ### max
 

--- a/src/@types/Context.ts
+++ b/src/@types/Context.ts
@@ -6,7 +6,7 @@ export interface Context {
   init(options: Omit<Options, 'context'>): void
 
   // function will be called to count request
-  increment(key: string): MaybePromise<{
+  increment(key: string, duration?: number, requestTime?: number): MaybePromise<{
     count: number
     nextReset: Date
   }>

--- a/src/@types/Options.ts
+++ b/src/@types/Options.ts
@@ -4,7 +4,8 @@ import type { ExtendedRequest, Server } from './Server.ts'
 
 export interface Options {
   // The duration for plugin to remember the requests (Default: 60000ms)
-  duration: number
+  // Can be a static number or a function that returns the duration based on the key and request
+  duration: number | ((key: string, request: ExtendedRequest) => number | Promise<number>)
 
   // Maximum of requests per specified duration (Default: 10)
   // Can be a static number or a function that returns the max based on the key and request

--- a/src/services/defaultContext.spec.ts
+++ b/src/services/defaultContext.spec.ts
@@ -107,4 +107,37 @@ describe('DefaultContext', () => {
 
     await shortContext.kill()
   })
+
+  it('should use per-call duration when provided to increment', async () => {
+    const ctx = new DefaultContext()
+    ctx.init({ ...defaultOptions, duration: 60000 })
+
+    const key = 'test-key-9'
+    const shortDuration = 50 // ms
+
+    // Create item with short duration via per-call override
+    await ctx.increment(key, shortDuration)
+
+    // Wait for the short duration to expire
+    await new Promise<void>(resolve => setTimeout(resolve, 60))
+
+    // Next increment should create a fresh item because the window expired
+    const result = await ctx.increment(key, shortDuration)
+    expect(result.count).toBe(1)
+
+    await ctx.kill()
+  })
+
+  it('should throw when duration is dynamic but no per-call duration is provided to increment', async () => {
+    const ctx = new DefaultContext()
+    ctx.init({ ...defaultOptions, duration: () => 60000 })
+
+    const key = 'test-key-10'
+
+    await expect(ctx.increment(key)).rejects.toThrow(
+      'DefaultContext.increment: duration is required when options.duration is a function but no per-call duration was provided'
+    )
+
+    await ctx.kill()
+  })
 })

--- a/src/services/defaultContext.ts
+++ b/src/services/defaultContext.ts
@@ -13,28 +13,32 @@ export class DefaultContext implements Context {
   private readonly id: string = (Math.random() + 1).toString(36).substring(7)
   private readonly maxSize: number
   private store!: AllocQuickLRU<string, Item>
-  private duration!: number
+  private duration: number | undefined
 
   public constructor(maxSize = 5000) {
     this.maxSize = maxSize
   }
 
   public init(options: Omit<Options, 'context'>) {
+    const durationDisplay = typeof options.duration === 'function' ? 'dynamic' : options.duration / 1000
     logger(
       `context:${this.id}`,
-      'initialized with maxSize: %d, and expire duration of %d seconds',
+      'initialized with maxSize: %d, and expire duration of %s seconds',
       this.maxSize,
-      options.duration / 1000
+      durationDisplay
     )
 
-    this.duration = options.duration
+    this.duration = typeof options.duration === 'function' ? undefined : options.duration
     this.store = new AllocQuickLRU<string, Item>({
       maxSize: this.maxSize,
     })
   }
 
-  public async increment(key: string) {
-    const now = Date.now()
+  public async increment(key: string, duration?: number, requestTime?: number) {
+    const effectiveDuration = duration ?? this.duration
+    if (effectiveDuration === undefined)
+      throw new Error('DefaultContext.increment: duration is required when options.duration is a function but no per-call duration was provided')
+    const now = requestTime ?? Date.now()
     let item = this.store.get(key)
 
     // if item is not found or expired, then issue a new one
@@ -48,7 +52,7 @@ export class DefaultContext implements Context {
 
       item = {
         count: 1,
-        nextReset: new Date(now + this.duration),
+        nextReset: new Date(now + effectiveDuration),
       }
     }
     // otherwise, increment the count

--- a/src/services/plugin.spec.ts
+++ b/src/services/plugin.spec.ts
@@ -120,4 +120,48 @@ describe('rate limit plugin', () => {
     expect(r2.status).toBe(404)
     expect(r3.status).toBe(429)
   })
+
+  it('should support dynamic duration as a function', async () => {
+    const durations: string[] = []
+
+    const app = new Elysia()
+      .use(plugin({
+        max: 2,
+        duration: (_key, _request) => {
+          durations.push(_key)
+          return 60000
+        },
+        scoping: 'global',
+        headers: true,
+      }))
+      .get('/test', () => 'ok')
+
+    const r1 = await app.handle(new Request('http://localhost/test'))
+    const r2 = await app.handle(new Request('http://localhost/test'))
+    const r3 = await app.handle(new Request('http://localhost/test'))
+
+    expect(r1.status).toBe(200)
+    expect(r2.status).toBe(200)
+    expect(r3.status).toBe(429)
+    expect(durations.length).toBeGreaterThan(0)
+  })
+
+  it('should set Retry-After header based on resolved dynamic duration', async () => {
+    const customDurationMs = 30000 // 30 seconds
+
+    const app = new Elysia()
+      .use(plugin({
+        max: 1,
+        duration: () => customDurationMs,
+        scoping: 'global',
+        headers: true,
+      }))
+      .get('/test', () => 'ok')
+
+    await app.handle(new Request('http://localhost/test'))
+    const r2 = await app.handle(new Request('http://localhost/test'))
+
+    expect(r2.status).toBe(429)
+    expect(r2.headers.get('Retry-After')).toBe(String(Math.ceil(customDurationMs / 1000)))
+  })
 })

--- a/src/services/plugin.ts
+++ b/src/services/plugin.ts
@@ -42,7 +42,9 @@ export const plugin = function rateLimitPlugin(userOptions?: Partial<Options>) {
   // do not make plugin to return async
   // otherwise request will be triggered twice
   return function registerRateLimitPlugin(app: Elysia) {
-    const seedValue = typeof options.max === 'function' ? 0 : options.max
+    const maxSeed = typeof options.max === 'function' ? 0 : options.max
+    const durationSeed = typeof options.duration === 'function' ? 0 : options.duration
+    const seedValue = `${maxSeed}:${durationSeed}`
     const plugin = new Elysia({
       name: 'elysia-rate-limit',
       seed: seedValue,
@@ -63,6 +65,7 @@ export const plugin = function rateLimitPlugin(userOptions?: Partial<Options>) {
       maxLimit: number,
       remaining: number,
       reset: number,
+      effectiveDuration: number,
       withRetryAfter = false
     ) => {
       if (!options.headers)
@@ -79,7 +82,7 @@ export const plugin = function rateLimitPlugin(userOptions?: Partial<Options>) {
       setHeader('RateLimit-Reset', String(reset))
 
       if (withRetryAfter)
-        setHeader('Retry-After', String(Math.ceil(options.duration / 1000)))
+        setHeader('Retry-After', String(Math.ceil(effectiveDuration / 1000)))
     }
 
     const applyRateLimit = async (
@@ -90,7 +93,13 @@ export const plugin = function rateLimitPlugin(userOptions?: Partial<Options>) {
       enhancedRequest: ExtendedRequest,
       clientKey: string
     ) => {
-      const { count, nextReset } = await options.context.increment(clientKey)
+      // Resolve duration (static or dynamic)
+      const requestTime = Date.now()
+      const effectiveDuration = typeof options.duration === 'function'
+        ? await options.duration(clientKey, enhancedRequest)
+        : options.duration
+
+      const { count, nextReset } = await options.context.increment(clientKey, effectiveDuration, requestTime)
 
       // Resolve max value (static or dynamic)
       const maxLimit = typeof options.max === 'function'
@@ -118,11 +127,11 @@ export const plugin = function rateLimitPlugin(userOptions?: Partial<Options>) {
         if (options.errorResponse instanceof Response) {
           // duplicate the response to avoid mutation
           const clonedResponse = options.errorResponse.clone()
-          writeRateLimitHeaders(clonedResponse.headers, maxLimit, remaining, reset, true)
+          writeRateLimitHeaders(clonedResponse.headers, maxLimit, remaining, reset, effectiveDuration, true)
           return clonedResponse
         }
 
-        writeRateLimitHeaders(set.headers, maxLimit, remaining, reset, true)
+        writeRateLimitHeaders(set.headers, maxLimit, remaining, reset, effectiveDuration, true)
 
         // set default status code
         set.status = 429
@@ -130,7 +139,7 @@ export const plugin = function rateLimitPlugin(userOptions?: Partial<Options>) {
         return options.errorResponse
       }
 
-      writeRateLimitHeaders(set.headers, maxLimit, remaining, reset)
+      writeRateLimitHeaders(set.headers, maxLimit, remaining, reset, effectiveDuration)
 
       logger(
         'plugin',


### PR DESCRIPTION
Mirror the existing dynamic `max` pattern for `duration`. The option now accepts `number | ((key, request) => number | Promise<number>)`.

- Widen `Options.duration` type
- Update `Context.increment` signature to accept per-call duration + requestTime
- Resolve effective duration in `applyRateLimit` before incrementing
- Capture `requestTime` before awaiting duration to preserve window anchor
- Fix instance deduplication seed to account for dynamic duration
- Update README with type, behavior note, and examples